### PR TITLE
Add zoom transition for card navigation

### DIFF
--- a/Features/CardDetail/Sources/CardDetailFeature.swift
+++ b/Features/CardDetail/Sources/CardDetailFeature.swift
@@ -59,7 +59,6 @@ import ScryfallKit
         let needsSetIcon = state.content.setIconURL == nil
         
         return .run { send in
-          // 1. Fire all requests concurrently using `async let`
           async let fetchedSetIconURL: URL? = needsSetIcon
           ? URL(string: client.getSet(of: card).iconSvgUri)
           : nil
@@ -246,7 +245,6 @@ public extension CardDetailFeature {
     case updateComboPieces(CardDataSource)
     case additionalInfosLoaded
     
-    // NEW BATcHED ACTION
     case additionalInfosBatchedLoaded(
       setIconURL: URL?,
       variants: CardDataSource?,

--- a/Features/CardDetail/Sources/CardDetailView.swift
+++ b/Features/CardDetail/Sources/CardDetailView.swift
@@ -94,119 +94,91 @@ public struct CardDetailView: View {
           legalities: content.card.legalities.all
         )
         
-        PriceView(
-          title: content.priceLabel,
-          subtitle: content.priceSubtitleLabel,
-          prices: content.card.prices,
-          usdLabel: content.usdLabel,
-          usdFoilLabel: content.usdFoilLabel,
-          tixLabel: content.tixLabel,
-          purchaseVendor: PurchaseVendor(purchaseURIs: content.card.purchaseUris)
-        )
-        
         let variantCards = content.variants.state.value
-        Group {
-          if let cards = variantCards {
-            HorizontalCardScrollView(
-              title: content.variants.title,
-              subtitle: content.variants.subtitle,
-              cards: cards,
-              isInitial: content.variants.state.isInitial
-            ) { action in
-              switch action {
-              case let .didSelectCard(card):
-                store.send(.didSelectVariant(card: card, queryType: content.queryType))
-              case let .didShowCardAtIndex(index):
-                store.send(.didShowVariant(index: index))
-              }
-            }
-          }
-        }
-        .animation(.smooth(duration: 0.3), value: variantCards != nil)
         
-        let relatedTokenCards = content.relatedTokens?.state.value
-        Group {
-          if let relatedTokensSection = content.relatedTokens,
-             let cards = relatedTokenCards {
-            HorizontalCardScrollView(
-              title: relatedTokensSection.title,
-              subtitle: relatedTokensSection.subtitle,
-              cards: cards,
-              isInitial: relatedTokensSection.state.isInitial
-            ) { action in
-              switch action {
-              case let .didSelectCard(card):
-                print(card)
-              case let .didShowCardAtIndex(index):
-                print(index)
-              }
+        if let cards = variantCards {
+          HorizontalCardScrollView(
+            title: content.variants.title,
+            subtitle: content.variants.subtitle,
+            cards: cards,
+            isInitial: content.variants.state.isInitial
+          ) { action in
+            switch action {
+            case let .didSelectCard(card):
+              store.send(.didSelectVariant(card: card, queryType: content.queryType))
+            case let .didShowCardAtIndex(index):
+              store.send(.didShowVariant(index: index))
             }
           }
         }
-        .animation(.smooth(duration: 0.3), value: relatedTokenCards != nil)
         
-        let relatedComboPieceCards = content.relatedComboPieces?.state.value
-        Group {
-          if let relatedComboPiecesSection = content.relatedComboPieces,
-             let cards = relatedComboPieceCards {
-            HorizontalCardScrollView(
-              title: relatedComboPiecesSection.title,
-              subtitle: relatedComboPiecesSection.subtitle,
-              cards: cards,
-              isInitial: relatedComboPiecesSection.state.isInitial
-            ) { action in
-              switch action {
-              case let .didSelectCard(card):
-                print(card)
-              case let .didShowCardAtIndex(index):
-                print(index)
-              }
+        if let relatedTokensSection = content.relatedTokens,
+           let cards = content.relatedTokens?.state.value {
+          HorizontalCardScrollView(
+            title: relatedTokensSection.title,
+            subtitle: relatedTokensSection.subtitle,
+            cards: cards,
+            isInitial: relatedTokensSection.state.isInitial
+          ) { action in
+            switch action {
+            case let .didSelectCard(card):
+              print(card)
+            case let .didShowCardAtIndex(index):
+              print(index)
             }
           }
         }
-        .animation(.smooth(duration: 0.3), value: relatedComboPieceCards != nil)
         
-        let relatedMeldPieceCards = content.relatedMeldPieces?.state.value
-        Group {
-          if let relatedMeldPiecesSection = content.relatedMeldPieces,
-             let cards = relatedMeldPieceCards {
-            HorizontalCardScrollView(
-              title: relatedMeldPiecesSection.title,
-              subtitle: relatedMeldPiecesSection.subtitle,
-              cards: cards,
-              isInitial: relatedMeldPiecesSection.state.isInitial
-            ) { action in
-              switch action {
-              case let .didSelectCard(card):
-                print(card)
-              case let .didShowCardAtIndex(index):
-                print(index)
-              }
+        if let relatedComboPiecesSection = content.relatedComboPieces,
+           let cards = content.relatedComboPieces?.state.value {
+          HorizontalCardScrollView(
+            title: relatedComboPiecesSection.title,
+            subtitle: relatedComboPiecesSection.subtitle,
+            cards: cards,
+            isInitial: relatedComboPiecesSection.state.isInitial
+          ) { action in
+            switch action {
+            case let .didSelectCard(card):
+              print(card)
+            case let .didShowCardAtIndex(index):
+              print(index)
             }
           }
         }
-        .animation(.smooth(duration: 0.3), value: relatedMeldPieceCards != nil)
         
-        let relatedMeldResultCards = content.relatedMeldResult?.state.value
-        Group {
-          if let relatedMeldResultSection = content.relatedMeldResult,
-             let cards = relatedMeldResultCards {
-            HorizontalCardScrollView(
-              title: relatedMeldResultSection.title,
-              subtitle: relatedMeldResultSection.subtitle,
-              cards: cards,
-              isInitial: relatedMeldResultSection.state.isInitial
-            ) { action in
-              switch action {
-              case let .didSelectCard(card):
-                print(card)
-              case let .didShowCardAtIndex(index):
-                print(index)
-              }
+        if let relatedMeldPiecesSection = content.relatedMeldPieces,
+           let cards = content.relatedMeldPieces?.state.value {
+          HorizontalCardScrollView(
+            title: relatedMeldPiecesSection.title,
+            subtitle: relatedMeldPiecesSection.subtitle,
+            cards: cards,
+            isInitial: relatedMeldPiecesSection.state.isInitial
+          ) { action in
+            switch action {
+            case let .didSelectCard(card):
+              print(card)
+            case let .didShowCardAtIndex(index):
+              print(index)
             }
           }
         }
-        .animation(.smooth(duration: 0.3), value: relatedMeldResultCards != nil)
+        
+        if let relatedMeldResultSection = content.relatedMeldResult,
+           let cards = content.relatedMeldResult?.state.value {
+          HorizontalCardScrollView(
+            title: relatedMeldResultSection.title,
+            subtitle: relatedMeldResultSection.subtitle,
+            cards: cards,
+            isInitial: relatedMeldResultSection.state.isInitial
+          ) { action in
+            switch action {
+            case let .didSelectCard(card):
+              print(card)
+            case let .didShowCardAtIndex(index):
+              print(index)
+            }
+          }
+        }
         
         SelectionView(
           items: [

--- a/Features/CardDetail/Sources/CardPagerView.swift
+++ b/Features/CardDetail/Sources/CardPagerView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 public struct CardPagerView: View {
   @Bindable var store: StoreOf<CardPagerFeature>
   @State var isAppeared: Bool = false
+  var zoomAnimation: Namespace.ID
   
   private var cardPairs: [(UUID, StoreOf<CardDetailFeature>)] {
     Array(zip(store.cards.ids, store.scope(state: \.cards, action: \.cards)))
@@ -13,22 +14,18 @@ public struct CardPagerView: View {
   
   public var body: some View {
     ScrollView(.horizontal, showsIndicators: false) {
-      if isAppeared {
-        LazyHStack(spacing: 0) {
-          ForEach(cardPairs, id: \.0) { _, childStore in
-            CardDetailView(store: childStore)
-              .containerRelativeFrame(.horizontal)
-          }
+      LazyHStack(spacing: 0) {
+        ForEach(cardPairs, id: \.0) { id, childStore in
+          CardDetailView(store: childStore)
+            .containerRelativeFrame(.horizontal)
         }
-        .scrollTargetLayout()
       }
+      .scrollTargetLayout()
     }
     .scrollTargetBehavior(.paging)
     .scrollPosition(id: $store.selectedId)
     .scrollEdgeEffectHidden()
-    .onAppear {
-      isAppeared = true
-    }
+    .navigationTransition(.zoom(sourceID: store.selectedId ?? UUID(), in: zoomAnimation))
     .sheet(
       item: $store.scope(state: \.showRulings, action: \.showRulings)
     ) { rulingStore in
@@ -38,7 +35,8 @@ public struct CardPagerView: View {
     }
   }
   
-  public init(store: StoreOf<CardPagerFeature>) {
+  public init(store: StoreOf<CardPagerFeature>, zoomAnimation: Namespace.ID) {
     self.store = store
+    self.zoomAnimation = zoomAnimation
   }
 }

--- a/Features/Query/Sources/QueryView.swift
+++ b/Features/Query/Sources/QueryView.swift
@@ -8,9 +8,10 @@ import NukeUI
 
 struct QueryView: View {
   @Bindable private var store: StoreOf<QueryFeature>
+  var zoomAnimation: Namespace.ID
   private let gridItems: [GridItem]
   
-  init(store: StoreOf<QueryFeature>) {
+  init(store: StoreOf<QueryFeature>, zoomAnimation: Namespace.ID) {
     self.store = store
     gridItems = [GridItem](
       repeating: GridItem(
@@ -19,6 +20,8 @@ struct QueryView: View {
       ),
       count: Int(store.numberOfColumns)
     )
+    
+    self.zoomAnimation = zoomAnimation
   }
   
   var body: some View {
@@ -78,9 +81,8 @@ struct QueryView: View {
       let cardInfo = value.0
       let index = value.1
       
-      let tiltDegrees = Double(abs(cardInfo.id.hashValue) % 60 - 30) / 10.0
-      
       Button {
+        print("Jun 1 - ", cardInfo.card.id)
         store.send(.didSelectCard(cardInfo.card, store.queryType))
       } label: {
         CardView(
@@ -94,6 +96,7 @@ struct QueryView: View {
           shouldShowShadow: false,
           send: nil
         )
+        .matchedTransitionSource(id: cardInfo.card.id, in: zoomAnimation)
       }
       .disabled(store.mode.isScrollable == false)
       .buttonStyle(.sinkableButtonStyle)

--- a/Features/Query/Sources/RootView.swift
+++ b/Features/Query/Sources/RootView.swift
@@ -5,12 +5,14 @@ import SwiftUI
 
 public struct RootView: View {
   @Bindable var store: StoreOf<QueryFeature>
+  var zoomAnimation: Namespace.ID
   
   public var body: some View {
-    QueryView(store: store)
+    QueryView(store: store, zoomAnimation: zoomAnimation)
   }
   
-  public init(store: StoreOf<QueryFeature>) {
+  public init(store: StoreOf<QueryFeature>, zoomAnimation: Namespace.ID) {
     self.store = store
+    self.zoomAnimation = zoomAnimation
   }
 }

--- a/Mooligan/Sources/BrowseFeature.swift
+++ b/Mooligan/Sources/BrowseFeature.swift
@@ -51,7 +51,7 @@ import CardScanner
   }
   
   @ObservableState struct State {
-    var selectedTab: TabInfo = .sets // 1. Added selection state
+    var selectedTab: TabInfo = .sets
     var sets: Browse.BrowseFeature.State
     var scan: CardScannerFeature.State
     var selectedSet: MTGSet?
@@ -63,6 +63,7 @@ import CardScanner
     case sets(Browse.BrowseFeature.Action)
     case scan(CardScannerFeature.Action)
     case path(StackActionOf<Path>)
+    case cardPagerStatePrepared(CardPagerFeature.State)
   }
   
   var body: some ReducerOf<Self> {
@@ -77,7 +78,6 @@ import CardScanner
       CardScannerFeature()
     }
     
-    // 1. Pass the function into Reduce, and attach .forEach here in the body!
     Reduce(coreReduce)
       .forEach(\.path, action: \.path)
   }
@@ -109,6 +109,10 @@ import CardScanner
     case .scan:
       return .none
       
+    case let .cardPagerStatePrepared(pagerState):
+      state.path.append(.showCardPager(pagerState))
+      return .none
+      
     case let .path(value):
       switch value {
       case let .element(id, action):
@@ -129,14 +133,17 @@ import CardScanner
               return .none
             }
             
-            let pagerState = CardPagerFeature.State(
-              cards: dataSource.cardDetails.map(\.card),
-              initialSelectedCard: card,
-              queryType: queryType
-            )
+            let cardDetails = dataSource.cardDetails
             
-            state.path.append(.showCardPager(pagerState))
-            return .none
+            return .run { send in
+              let cards = cardDetails.map(\.card)
+              let pagerState = CardPagerFeature.State(
+                cards: cards,
+                initialSelectedCard: card,
+                queryType: queryType
+              )
+              await send(.cardPagerStatePrepared(pagerState))
+            }
             
           case .loadMoreCardsIfNeeded:
             break
@@ -151,7 +158,7 @@ import CardScanner
             break
           }
           
-        case let .showCardPager(value):
+        case .showCardPager:
           break
           
         case let .showCardDetail(value):

--- a/Mooligan/Sources/MooliganApp.swift
+++ b/Mooligan/Sources/MooliganApp.swift
@@ -31,6 +31,7 @@ struct MooliganApp: App {
 
 struct RootView: View {
   @Bindable var store: StoreOf<Feature>
+  @Namespace var zoomAnimation
   
   var body: some View {
     TabView(selection: $store.selectedTab) {
@@ -46,13 +47,13 @@ struct RootView: View {
             } destination: { store in
               switch store.case {
               case let .showCardPager(value):
-                CardDetail.CardPagerView(store: value)
+                CardDetail.CardPagerView(store: value, zoomAnimation: zoomAnimation)
                 
               case let .showCardDetail(value):
                 CardDetail.RootView(store: value)
                 
               case let .showSetDetail(value):
-                Query.RootView(store: value)
+                Query.RootView(store: value, zoomAnimation: zoomAnimation)
               }
             }
             


### PR DESCRIPTION
Wire a matched zoom transition through the app: introduce a @Namespace zoomAnimation in the root view and pass it into Query.RootView/QueryView and CardDetail.CardPagerView/CardPagerView. QueryView now marks card views as matchedTransitionSource; CardPagerView uses navigationTransition(.zoom) to animate between grid and pager.

Also: adjust CardPagerView layout/initializer to accept the namespace, simplify several conditional Group wrappers and animations in CardDetailView, and change BrowseFeature to prepare and send a CardPagerFeature.State asynchronously via a new cardPagerStatePrepared action before pushing the pager route. Minor cleanup: remove an outdated comment in CardDetailFeature.