### PR TITLE
Simplify CardRemoteImageView and update CardDetail

### DIFF
--- a/Core/DesignComponents/Sources/CardRemoteImageView.swift
+++ b/Core/DesignComponents/Sources/CardRemoteImageView.swift
@@ -36,10 +36,6 @@ public struct CardRemoteImageView: View {
       )
     }
     
-    if let size {
-      transformers.append(ImageProcessors.Resize(size: size, unit: .points, contentMode: .aspectFit, crop: false, upscale: false))
-    }
-    
     self.transformers = transformers
     self.size = size
     self.id = id
@@ -62,9 +58,8 @@ public struct CardRemoteImageView: View {
             .blur(radius: 34.0)
         }
       }
-      .aspectRatio(MagicCardImageRatio.widthToHeight.rawValue, contentMode: .fit)
     }
-    .frame(width: size?.width, height: size?.height, alignment: .center)
+    .aspectRatio(MagicCardImageRatio.widthToHeight.rawValue, contentMode: .fit)
     .onGeometryChange(
       for: CGSize.self,
       of: { proxy in
@@ -78,13 +73,6 @@ public struct CardRemoteImageView: View {
     )
     .clipShape(
       RoundedRectangle(cornerRadius: cornerRadius ?? 0)
-    )
-    .overlay(
-      RoundedRectangle(cornerRadius: cornerRadius ?? 0)
-        .strokeBorder(
-          .separator,
-          lineWidth: 1 / displayScale
-        )
     )
   }
 }

--- a/Features/CardDetail/Sources/CardDetailFeature.swift
+++ b/Features/CardDetail/Sources/CardDetailFeature.swift
@@ -82,7 +82,7 @@ import ScryfallKit
           if let result = variantsResult {
             let newCards = result.data.filter { $0.id != card.id }
             variantsDataSource = CardDataSource(
-              cards: newCards,
+              cards: [card] + newCards,
               hasNextPage: result.hasMore ?? false,
               total: result.totalCards ?? 0
             )

--- a/Features/CardDetail/Sources/CardDetailView.swift
+++ b/Features/CardDetail/Sources/CardDetailView.swift
@@ -94,9 +94,17 @@ public struct CardDetailView: View {
           legalities: content.card.legalities.all
         )
         
-        let variantCards = content.variants.state.value
+        PriceView(
+          title: content.priceLabel,
+          subtitle: content.priceSubtitleLabel,
+          prices: content.card.prices,
+          usdLabel: content.usdLabel,
+          usdFoilLabel: content.usdFoilLabel,
+          tixLabel: content.tixLabel,
+          purchaseVendor: PurchaseVendor(purchaseURIs: content.card.purchaseUris)
+        )
         
-        if let cards = variantCards {
+        if let cards = content.variants.state.value {
           HorizontalCardScrollView(
             title: content.variants.title,
             subtitle: content.variants.subtitle,


### PR DESCRIPTION
Card detail and image view adjustments:

- CardRemoteImageView: remove the optional resize image processor, drop the explicit frame and stroke overlay, and adjust aspectRatio placement to simplify layout and rely on geometry for sizing.
- CardDetailFeature: include the current (base) card at the front of the variants data source so the base card appears alongside its variants.
- CardDetailView: insert PriceView into the detail layout and remove the intermediate variantCards variable, using content.variants.state.value directly for the HorizontalCardScrollView.

These changes tidy up image rendering behavior and surface pricing alongside variants in the card detail UI.