### PR TITLE
Add scrollEdgeEffect, BindingReducer, async send

### DIFF
--- a/Features/Browse/Sources/BrowseFeature.swift
+++ b/Features/Browse/Sources/BrowseFeature.swift
@@ -8,6 +8,8 @@ import ScryfallKit
   @Dependency(\.continuousClock) var clock
   
   public var body: some ReducerOf<Self> {
+    BindingReducer()
+    
     Reduce { state, action in
       switch action {
       case .binding(\.query):

--- a/Features/Browse/Sources/SetsView.swift
+++ b/Features/Browse/Sources/SetsView.swift
@@ -112,10 +112,10 @@ struct SetsView: View {
             .padding(.bottom, 3.0)
         }
       }
+      .scrollEdgeEffectStyle(.soft, for: .all)
       .listStyle(.plain)
       .listSectionSeparator(.hidden)
       .searchable(text: $store.query)
-      .searchToolbarBehavior(.minimize)
       .background { Color(.systemGroupedBackground).ignoresSafeArea() }
       .redacted(reason: store.mode.isPlaceholder ? .placeholder : [])
       .scrollDisabled(store.mode.isPlaceholder)

--- a/Features/CardScanner/Sources/CardScannerFeature.swift
+++ b/Features/CardScanner/Sources/CardScannerFeature.swift
@@ -224,7 +224,9 @@ public enum ScannerStatus: Equatable, Sendable {
       
     case let .variantsLoaded(variants):
       state.pendingVariants = variants
-      return .send(.mergePendingVariants, animation: .default)
+      return .run { send in
+        await send(.mergePendingVariants, animation: .default)
+      }
       
     case .mergePendingVariants:
       guard

--- a/Features/CardScanner/Sources/RootView.swift
+++ b/Features/CardScanner/Sources/RootView.swift
@@ -50,6 +50,7 @@ public struct RootView: View {
           }
         }
       }
+      .scrollEdgeEffectStyle(.soft, for: .all)
     }
     .onGeometryChange(for: EdgeInsets.self, of: { $0.safeAreaInsets }) { insets in
       store.send(.updateSafeAreas(top: insets.top, bottom: insets.bottom))
@@ -80,7 +81,7 @@ public struct RootView: View {
        let cardInfo = store.dataSource?.cardDetails.first {
       let targetCorners: QuadCorners? = store.isMorphed
       ? uprightCorners(for: viewSize)
-      : store.latestTrackedCorners
+      : store.latestTrackedCorners`
       
       if let cornersToDraw = targetCorners {
         let containerWidth = viewSize.width * 0.75

--- a/Features/Query/Sources/QueryView.swift
+++ b/Features/Query/Sources/QueryView.swift
@@ -39,6 +39,7 @@ struct QueryView: View {
         }
       }
     }
+    .scrollEdgeEffectStyle(.soft, for: .all)
     .contentMargins(
       .all,
       EdgeInsets(top: 0, leading: 5, bottom: 13.0, trailing: 5),


### PR DESCRIPTION
Add BindingReducer to BrowseFeature to enable bindings. Apply .scrollEdgeEffectStyle(.soft, for: .all) to SetsView, RootView and QueryView to unify scroll edge appearance. Remove .searchToolbarBehavior(.minimize) from SetsView. Replace a synchronous .send return in CardScannerFeature with a .run { await send(...) } to perform the send asynchronously. Also remove a stray backtick in RootView.