### PR TITLE
Use design colors & clear search on collapse

### DIFF
--- a/Core/DesignComponents/Resources/Assets.xcassets/backgroundColor.colorset/Contents.json
+++ b/Core/DesignComponents/Resources/Assets.xcassets/backgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.850",
+          "green" : "0.850",
+          "red" : "0.850"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.100",
+          "green" : "0.100",
+          "red" : "0.100"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Core/DesignComponents/Resources/Assets.xcassets/setRowColor.colorset/Contents.json
+++ b/Core/DesignComponents/Resources/Assets.xcassets/setRowColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.961",
-          "green" : "0.961",
-          "red" : "0.961"
+          "blue" : "0.950",
+          "green" : "0.950",
+          "red" : "0.950"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.122",
-          "green" : "0.122",
-          "red" : "0.122"
+          "blue" : "0.150",
+          "green" : "0.150",
+          "red" : "0.150"
         }
       },
       "idiom" : "universal"

--- a/Core/DesignComponents/Sources/SearchBar.swift
+++ b/Core/DesignComponents/Sources/SearchBar.swift
@@ -20,15 +20,21 @@ public struct SearchBar: View {
   public var body: some View {
     HStack(spacing: 8.0) {
       if isExpanded {
-        TextField(placeholder, text: $text)
-          .focused($isSearchFocused)
-          .textFieldStyle(.plain)
-          .autocorrectionDisabled()
-          .submitLabel(.search)
-          .id("searchTextField")
-          .frame(maxWidth: .infinity, minHeight: 28.0)
-          .padding(EdgeInsets(top: 8, leading: 13, bottom: 8, trailing: 13))
-          .glassEffect(.regular.interactive())
+        HStack {
+          Image(systemName: "magnifyingglass")
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundColor(.primary)
+          
+          TextField(placeholder, text: $text)
+            .focused($isSearchFocused)
+            .textFieldStyle(.plain)
+            .autocorrectionDisabled()
+            .submitLabel(.search)
+            .id("searchTextField")
+            .frame(maxWidth: .infinity, minHeight: 28.0)
+        }
+        .padding(EdgeInsets(top: 8, leading: 13, bottom: 8, trailing: 13))
+        .glassEffect(.regular.interactive())
         
         Button {
           isExpanded = false

--- a/Features/Browse/Sources/SetRow.swift
+++ b/Features/Browse/Sources/SetRow.swift
@@ -53,7 +53,7 @@ struct SetRow: View {
             style: .continuous
           )
           .foregroundStyle(
-            colorScheme == .light ? Color(.systemBackground) : Color(.secondarySystemGroupedBackground)
+            DesignComponentsAsset.setRowColor.swiftUIColor
           )
         }
       }

--- a/Features/Browse/Sources/SetsView.swift
+++ b/Features/Browse/Sources/SetsView.swift
@@ -155,12 +155,13 @@ struct SetsView: View {
       }
     }
     .scrollEdgeEffectStyle(.soft, for: .all)
+    .toolbarMinimizationBehavior(.onScrollDown, for: .navigationBar)
     .listStyle(.plain)
     .listSectionSeparator(.hidden)
     .conditionalModifier(isScrollable, transform: { view in
       view.searchable(text: $store.query)
     })
-    .background { Color(.systemGroupedBackground).ignoresSafeArea() }
+    .background(DesignComponentsAsset.backgroundColor.swiftUIColor.ignoresSafeArea())
     .redacted(reason: isPlaceholder ? .placeholder : [])
     .scrollDisabled(isPlaceholder)
     .allowsHitTesting(isPlaceholder == false)

--- a/Features/Query/Sources/QueryFeature.swift
+++ b/Features/Query/Sources/QueryFeature.swift
@@ -141,6 +141,13 @@ public struct QueryFeature: Sendable {
           cancelInFlight: true
         )
         
+      case .binding(\.isSearchExpanded):
+        if !state.isSearchExpanded {
+          state.query.name = ""
+        }
+        
+        return .none
+        
       case .binding:
         return .none
         

--- a/Features/Query/Sources/QueryView.swift
+++ b/Features/Query/Sources/QueryView.swift
@@ -55,7 +55,7 @@ struct QueryView: View {
           SearchBar(
             text: $store.query.name,
             isExpanded: $store.isSearchExpanded,
-            placeholder: "Search for Magic cards..."
+            placeholder: store.searchPrompt
           )
         }
       }
@@ -92,7 +92,7 @@ struct QueryView: View {
       }
       .opacity(store.mode == .loading ? 1 : 0)
     }
-    .background(colorScheme == .light ? Color(.systemGroupedBackground) : Color(.secondarySystemBackground))
+    .background(DesignComponentsAsset.backgroundColor.swiftUIColor)
     .task { store.send(.viewAppeared) }
   }
   


### PR DESCRIPTION
Replace system colors with DesignComponents assets and adjust search behavior. Renamed/updated color assets (backgroundColor, added setRowColor) and updated UI to use DesignComponentsAsset.* colors in SetRow, SetsView and QueryView. Add toolbar minimization behavior for navigation bar in SetsView. In QueryFeature, clear the query.name when search is collapsed (binding to isSearchExpanded). QueryView now uses store.searchPrompt as the search placeholder. These changes unify app styling with the design system and ensure search state resets when collapsed.