### PR TITLE
Add image loading state tracking to CardView

### DIFF
--- a/Core/DesignComponents/Sources/CardRemoteImageView.swift
+++ b/Core/DesignComponents/Sources/CardRemoteImageView.swift
@@ -5,8 +5,11 @@ import SwiftUI
 
 public struct CardRemoteImageView: View {
   public let url: URL
+  
   @Environment(\.displayScale) private var displayScale
   @State private var cornerRadius: CGFloat?
+  @Binding var isImageLoaded: Bool
+  
   private let transformers: [ImageProcessing]
   private let size: CGSize?
   private let isLandscape: Bool
@@ -19,29 +22,27 @@ public struct CardRemoteImageView: View {
     isTransformed: Bool = false,
     size: CGSize? = nil,
     id: String,
-    priority: ImageRequest.Priority = .normal
+    priority: ImageRequest.Priority = .normal,
+    isImageLoaded: Binding<Bool> // 2. Add to init
   ) {
-    self.isLandscape = isLandscape
     self.url = url
-    
-    var transformers: [ImageProcessing] = []
-    
-    if isLandscape {
-      transformers.append(
-        RotationImageProcessor(degrees: 90)
-      )
-    }
-    
-    if isTransformed {
-      transformers.append(
-        FlipImageProcessor()
-      )
-    }
-    
-    self.transformers = transformers
+    self.isLandscape = isLandscape
     self.size = size
     self.id = id
     self.priority = priority
+    
+    self._isImageLoaded = isImageLoaded
+    var transformers: [ImageProcessing] = []
+    
+    if isLandscape {
+      transformers.append(RotationImageProcessor(degrees: 90))
+    }
+    
+    if isTransformed {
+      transformers.append(FlipImageProcessor())
+    }
+    
+    self.transformers = transformers
   }
   
   public var body: some View {
@@ -56,6 +57,11 @@ public struct CardRemoteImageView: View {
       Group {
         if let image = state.image {
           image.resizable()
+            .onAppear {
+              if isImageLoaded != true {
+                isImageLoaded = true
+              }
+            }
         } else {
           Color.primary.opacity(0.3)
             .shimmering()

--- a/Core/DesignComponents/Sources/CardView.swift
+++ b/Core/DesignComponents/Sources/CardView.swift
@@ -85,6 +85,7 @@ public struct CardView: View {
   private let displayableCard: DisplayableCardImage
   private let accessoryInfo: AccessoryInfo
   private let send: ((Action) -> Void)?
+  @State private var isImageLoaded: Bool = false
   
   @Environment(\.displayScale) private var displayScale
   private var strokeScale: CGFloat { max(displayScale, 1) }
@@ -116,7 +117,8 @@ public struct CardView: View {
             isLandscape: layoutConfiguration?.rotation == .landscape,
             isTransformed: false,
             size: layoutConfiguration?.size,
-            id: id
+            id: id,
+            isImageLoaded: $isImageLoaded
           )
           .ifLet(
             shadowConfiguration,
@@ -133,7 +135,9 @@ public struct CardView: View {
       }
       .zIndex(1)
       
-      accessoryView.zIndex(0)
+      accessoryView
+        .zIndex(0)
+        .redacted(reason: isImageLoaded ? [] : .placeholder)
     }
   }
   
@@ -149,7 +153,8 @@ public struct CardView: View {
       isLandscape: layoutConfiguration?.rotation == .landscape,
       isTransformed: true,
       size: layoutConfiguration?.size,
-      id: id
+      id: id,
+      isImageLoaded: $isImageLoaded
     )
     .ifLet(
       shadowConfiguration,
@@ -172,7 +177,8 @@ public struct CardView: View {
       isLandscape: layoutConfiguration?.rotation == .landscape,
       isTransformed: false,
       size: layoutConfiguration?.size,
-      id: id
+      id: id,
+      isImageLoaded: $isImageLoaded
     )
     .ifLet(
       shadowConfiguration,
@@ -213,7 +219,8 @@ public struct CardView: View {
       isLandscape: layoutConfiguration?.rotation == .landscape,
       isTransformed: false,
       size: layoutConfiguration?.size,
-      id: id
+      id: id,
+      isImageLoaded: $isImageLoaded
     )
     .ifLet(
       shadowConfiguration,
@@ -281,4 +288,3 @@ public struct CardView: View {
     self.send = send
   }
 }
-

--- a/Core/Networking/Sources/CardDetail/MockCardDetailRequestClient.swift
+++ b/Core/Networking/Sources/CardDetail/MockCardDetailRequestClient.swift
@@ -64,7 +64,7 @@ public extension Card {
       ),
       prices: .init(
         tix: nil,
-        usd: "120.90",
+        usd: "0.00",
         usdFoil: "240.90",
         eur: "100"
       ),

--- a/Features/CardDetail/Sources/Widgets/HorizontalCardScrollView.swift
+++ b/Features/CardDetail/Sources/Widgets/HorizontalCardScrollView.swift
@@ -60,7 +60,7 @@ struct HorizontalCardScrollView: View {
               }
             )
             .buttonStyle(.sinkableButtonStyle)
-//            .task { send(.didShowCardAtIndex(index)) }
+//            .task { send(.didShowCardAtIndex(<#T##Int#>)) }
           }
         }
       }

--- a/Features/Query/Sources/QueryView.swift
+++ b/Features/Query/Sources/QueryView.swift
@@ -19,7 +19,7 @@ struct QueryView: View {
   
   private var gridItems: [GridItem] {
     [GridItem](
-      repeating: GridItem(spacing: 13.0, alignment: .center),
+      repeating: GridItem(spacing: 8.0, alignment: .center),
       count: max(1, Int(store.numberOfColumns))
     )
   }


### PR DESCRIPTION
Track image loading state via binding in CardRemoteImageView and use it to conditionally redact accessory content until the image loads. Also adjusts grid spacing in QueryView and updates mock card pricing.