### PR TITLE
Add debugging prints, tweak card grid styling

### DIFF
--- a/Features/Browse/Sources/BrowseFeature.swift
+++ b/Features/Browse/Sources/BrowseFeature.swift
@@ -67,6 +67,7 @@ import ScryfallKit
         return .none
       }
     }
+    ._printChanges()
   }
   
   public init() {}

--- a/Features/CardDetail/Sources/CardPagerFeature.swift
+++ b/Features/CardDetail/Sources/CardPagerFeature.swift
@@ -92,6 +92,7 @@ public struct CardPagerFeature: Sendable {
     .ifLet(\.$showRulings, action: \.showRulings) {
       RulingFeature()
     }
+    ._printChanges()
   }
   
   public init() {}

--- a/Features/Query/Sources/CardGridContentView.swift
+++ b/Features/Query/Sources/CardGridContentView.swift
@@ -17,9 +17,15 @@ struct CardGridContentView: View {
           store.send(.didSelectCard(cardInfo.card, store.queryType))
         } label: {
           ZStack(alignment: .top) {
-            Color.primary.opacity(0.1)
-              .clipShape(
+            Color.clear
+              .overlay(
                 RoundedRectangle(cornerRadius: layoutConfiguration.cornerRadius)
+                  .stroke(
+                    (colorScheme == .dark ? Color.white.opacity(0.169) : Color.black.opacity(0.225)).blendMode(
+                      colorScheme == .dark ? .plusLighter : .plusDarker
+                    ),
+                    lineWidth: 1 / displayScale
+                  )
               )
               .frame(width: layoutConfiguration.size.width, height: layoutConfiguration.size.height, alignment: .center)
             

--- a/Features/Query/Sources/QueryFeature.swift
+++ b/Features/Query/Sources/QueryFeature.swift
@@ -248,6 +248,7 @@ public struct QueryFeature: Sendable {
         return .none
       }
     }
+    ._printChanges()
   }
   
   public init() {}

--- a/Features/Query/Sources/QueryView.swift
+++ b/Features/Query/Sources/QueryView.swift
@@ -88,7 +88,7 @@ struct QueryView: View {
       for: .scrollContent
     )
     .scrollDisabled(store.mode.isScrollable == false)
-    .scrollPosition($store.scrollPosition)
+//    .scrollPosition($store.scrollPosition)
     .scrollBounceBehavior(.basedOnSize)
     .navigationTitle(store.title)
     .navigationBarTitleDisplayMode(.inline)

--- a/Mooligan/Sources/BrowseFeature.swift
+++ b/Mooligan/Sources/BrowseFeature.swift
@@ -84,6 +84,7 @@ public struct Feature {
     
     Reduce(coreReduce)
       .forEach(\.path, action: \.path)
+      ._printChanges()
   }
   
   public init() {}


### PR DESCRIPTION
Remove stray Untitled.swift and add ._printChanges() to several reducers (BrowseFeature, CardPagerFeature, QueryFeature, and Mooligan BrowseFeature) to aid debugging of state changes. Update CardGridContentView to use a clear background with a rounded-rectangle stroked overlay using blend modes for improved border rendering. Comment out the scrollPosition binding in QueryView (temporarily disabled).